### PR TITLE
Add initial vector class

### DIFF
--- a/Vector.h
+++ b/Vector.h
@@ -7,11 +7,25 @@
 #define xmalloc(T, count) \
     ((T*)malloc(sizeof(T) * (count)))
 
+/**
+ * A dynamic array of contiguous memory, like std::vector.
+ */
 template<typename X>
 class mal_vector {
  public:
+    /**
+     * Pointer to first element.
+     */
     X* data;
+
+    /**
+     * Number of elements currently in the vector.
+     */
     size_t size;
+
+    /**
+     * Number of elements for which memory is reserved.
+     */
     size_t capacity;
 
  public:
@@ -19,8 +33,14 @@ class mal_vector {
     // Constructors & destructor
     //
 
+    /**
+     * Construct an empty vector.
+     */
     mal_vector() : data(0), size(0), capacity(0) { }
 
+    /**
+     * Construct a copy of another vector.
+     */
     mal_vector(const mal_vector& other) {
         if (other.capacity == 0) {
             data = 0;
@@ -36,6 +56,9 @@ class mal_vector {
         }
     }
 
+    /**
+     * Construct vector by stealing another's contents.
+     */
     mal_vector(mal_vector&& other) {
         data = other.data;
         size = other.size;
@@ -44,6 +67,9 @@ class mal_vector {
         other.size = other.capacity = 0;
     }
 
+    /**
+     * Free a vector's memory and destroy its contents.
+     */
     ~mal_vector() {
         for (size_t i = 0; i < size; i++) {
             data[i].~X();
@@ -55,6 +81,9 @@ class mal_vector {
     // Operators
     //
 
+    /**
+     * Destroy the current contents and copy in another vector's.
+     */
     void operator=(const mal_vector& other) {
         for (size_t i = 0; i < size; i++) {
             data[i].~X();
@@ -74,6 +103,9 @@ class mal_vector {
         }
     }
 
+    /**
+     * Destroy the current contents and move in another vector's.
+     */
     void operator=(mal_vector&& other) {
         for (size_t i = 0; i < size; i++) {
             data[i].~X();
@@ -90,15 +122,28 @@ class mal_vector {
     // Element accesses
     //
 
+    /**
+     * Access a single element.
+     */
     X& operator[](size_t i) {
         assert(i < size);
         return data[i];
     }
 
+    /**
+     * Get a pointer to the first element.
+     *
+     * Useful mostly in range-for loops.
+     */
     X* begin() {
         return data;
     }
 
+    /**
+     * Get a pointer past the last element.
+     *
+     * Useful mostly in range-for loops.
+     */
     X* end() {
         return data + size;
     }
@@ -107,18 +152,27 @@ class mal_vector {
     // Element additions
     //
 
+    /**
+     * Add a element to the end by copying an existing value.
+     */
     void push(const X& x) {
         grow();
         new (data + size) X(x);
         size++;
     }
 
+    /**
+     * Add a element to the end by moving an existing value.
+     */
     void push(X&& x) {
         grow();
         new (data + size) X(static_cast<X&&>(x));
         size++;
     }
 
+    /**
+     * Add a element to an arbitrary position by copying an existing value.
+     */
     void insert(size_t i, const X& x) {
         // FIXME: Does not call move constructors.
         assert(i <= size);
@@ -128,6 +182,9 @@ class mal_vector {
         size++;
     }
 
+    /**
+     * Add a element to an arbitrary position by moving an existing value.
+     */
     void insert(size_t i, X&& x) {
         // FIXME: Does not call move constructors.
         assert(i <= size);
@@ -137,6 +194,9 @@ class mal_vector {
         size++;
     }
 
+    /**
+     * Add an array of element to the end by copying existing values.
+     */
     void append(size_t n, const X* xs) {
         assert(n <= size);
         reserve(size + n);  // FIXME: Choose better size.
@@ -151,12 +211,18 @@ class mal_vector {
     // Element removals
     //
 
+    /**
+     * Remove the last element.
+     */
     void pop() {
         assert(size);
         data[size - 1].~X();
         size--;
     }
 
+    /**
+     * Remove an element.
+     */
     void erase(size_t i) {
         assert(i < size);
         for (size_t j = i; j < size - 1; j++) {
@@ -170,8 +236,13 @@ class mal_vector {
     // Miscellaneous
     //
 
-    // Calls move constructors (which empties the old objects), but not call
-    // destructors on the just-moved objects since they are hopefully empty.
+    /**
+     * Allocate uninitialized memory for a number of elements.
+     *
+     * Calls move constructors (which empties the old objects), but does not
+     * call destructors on the just-moved objects since they are hopefully
+     * empty.
+     */
     void reserve(size_t n) {
         assert(n > capacity);
         X* newData = xmalloc(X, n);
@@ -183,6 +254,12 @@ class mal_vector {
         capacity = n;
     }
 
+    /**
+     * Grow or shrink the size of the vector, constructing and destructing
+     * elements as necessary.
+     *
+     * If necessary, additional memory will be allocated.
+     */
     void resize(size_t n) {
         if (n > capacity) {
             reserve(n);
@@ -200,12 +277,18 @@ class mal_vector {
         size = n;
     }
 
+    /**
+     * Grow the vector if it is full.
+     */
     void grow() {
         if (size == capacity) {
             reserve(size == 0 ? 4 : size * 2);  // FIXME: Choose better size.
         }
     }
 
+    /**
+     * Resize the vector to 0 elements.
+     */
     void clear() {
         for (size_t i = 0; i < size; i++) {
             data[i].~X();
@@ -213,6 +296,12 @@ class mal_vector {
         size = 0;
     }
 
+    /**
+     * Drop the vector's data pointer so it won't be freed upon vector
+     * destruction.
+     *
+     * Resets the vector to its default, empty state.
+     */
     void reset() {
         data = 0;
         size = capacity = 0;

--- a/Vector.h
+++ b/Vector.h
@@ -232,7 +232,7 @@ class mal_vector {
     }
 
     //
-    // Miscellaneous
+    // Memory management
     //
 
     /**

--- a/Vector.h
+++ b/Vector.h
@@ -1,0 +1,220 @@
+#ifndef VECTOR_H_
+#define VECTOR_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+// Does not call move constructors in its own move constructor or when growing.
+template<typename X>
+class mal_vector {
+ public:
+    X* data;
+    size_t size;
+    size_t capacity;
+
+ public:
+    //
+    // Constructors & destructor
+    //
+
+    mal_vector() : data(0), size(0), capacity(0) { }
+
+    mal_vector(const mal_vector& other) {
+        if (other.capacity == 0) {
+            data = 0;
+            size = capacity = 0;
+        }
+        else {
+            data = malloc(X, other.capacity);
+            size = other.size;
+            capacity = other.capacity;
+            for (size_t i = 0; i < size; i++) {
+                new (data + i) X(other.data[i]);
+            }
+        }
+    }
+
+    mal_vector(mal_vector&& other) {
+        data = other.data;
+        size = other.size;
+        capacity = other.capacity;
+        other.data = 0;
+        other.size = other.capacity = 0;
+    }
+
+    ~mal_vector() {
+        for (size_t i = 0; i < size; i++) {
+            data[i].~X();
+        }
+        free(data);
+    }
+
+    //
+    // Operators
+    //
+
+    void operator=(const mal_vector& other) {
+        for (size_t i = 0; i < size; i++) {
+            data[i].~X();
+        }
+        free(data);
+        if (other.capacity == 0) {
+            data = 0;
+            size = capacity = 0;
+        }
+        else {
+            data = malloc(X, other.capacity);
+            size = other.size;
+            capacity = other.capacity;
+            for (size_t i = 0; i < size; i++) {
+                new (data + i) X(other[i]);
+            }
+        }
+    }
+
+    void operator=(mal_vector&& other) {
+        for (size_t i = 0; i < size; i++) {
+            data[i].~X();
+        }
+        free(data);
+        data = other.data;
+        size = other.size;
+        capacity = other.capacity;
+        other.data = 0;
+        other.size = other.capacity = 0;
+    }
+
+    //
+    // Element accesses
+    //
+
+    X& operator[](size_t i) {
+        assert(i < size);
+        return data[i];
+    }
+
+    X* begin() {
+        return data;
+    }
+
+    X* end() {
+        return data + size;
+    }
+
+    //
+    // Element additions
+    //
+
+    void push(const X& x) {
+        grow();
+        new (data + size) X(x);
+        size++;
+    }
+
+    void push(X&& x) {
+        grow();
+        new (data + size) X(static_cast<X&&>(x));
+        size++;
+    }
+
+    void insert(size_t i, const X& x) {
+        // FIXME: Does not call move constructors.
+        assert(i <= size);
+        grow();
+        memmove(data + i, data + i + 1, sizeof(X) * (size - i));
+        new (data + i) X(x);
+        size++;
+    }
+
+    void insert(size_t i, X&& x) {
+        // FIXME: Does not call move constructors.
+        assert(i <= size);
+        grow();
+        memmove(data + i, data + i + 1, sizeof(X) * (size - i));
+        new (data + i) X(static_cast<X&&>(x));
+        size++;
+    }
+
+    void append(size_t n, const X* xs) {
+        assert(n <= size);
+        reserve(size + n);  // FIXME: Choose better size.
+        for (size_t i = 0; i < n; i++) {
+            new (data + size + i) X(xs[i]);
+        }
+        size += n;
+    }
+
+
+    //
+    // Element removals
+    //
+
+    void pop() {
+        assert(size);
+        data[size - 1].~X();
+        size--;
+    }
+
+    void erase(size_t i) {
+        assert(i < size);
+        for (size_t j = i; j < size - 1; j++) {
+            data[j] = static_cast<X&&>(data[j + 1]);
+        }
+        size--;
+        data[size].~X();
+    }
+
+    //
+    // Miscellaneous
+    //
+
+    // Calls move constructors (which empties the old objects), but not call
+    // destructors on the just-moved objects since they are hopefully empty.
+    void reserve(size_t n) {
+        assert(n > capacity);
+        X* newData = malloc(X, n);
+        for (size_t i = 0; i < size; i++) {
+            new (newData + i) X(static_cast<X&&>(data[i]));
+        }
+        free(data);
+        data = newData;
+        capacity = n;
+    }
+
+    void resize(size_t n) {
+        if (n > capacity) {
+            reserve(n);
+        }
+        if (n > size) {
+            for (size_t i = size; i < n; i++) {
+                new (data + i) X;
+            }
+        }
+        else if (n < size) {
+            for (size_t i = n; i < size; i++) {
+                data[i].~X();
+            }
+        }
+        size = n;
+    }
+
+    void grow() {
+        if (size == capacity) {
+            reserve(size == 0 ? 4 : size * 2);  // FIXME: Choose better size.
+        }
+    }
+
+    void clear() {
+        for (size_t i = 0; i < size; i++) {
+            data[i].~X();
+        }
+        size = 0;
+    }
+
+    void reset() {
+        data = 0;
+        size = capacity = 0;
+    }
+};
+
+#endif

--- a/Vector.h
+++ b/Vector.h
@@ -126,7 +126,6 @@ class mal_vector {
      * Access a single element.
      */
     X& operator[](size_t i) {
-        assert(i < size);
         return data[i];
     }
 
@@ -175,7 +174,6 @@ class mal_vector {
      */
     void insert(size_t i, const X& x) {
         // FIXME: Does not call move constructors.
-        assert(i <= size);
         grow();
         memmove(data + i, data + i + 1, sizeof(X) * (size - i));
         new (data + i) X(x);
@@ -187,7 +185,6 @@ class mal_vector {
      */
     void insert(size_t i, X&& x) {
         // FIXME: Does not call move constructors.
-        assert(i <= size);
         grow();
         memmove(data + i, data + i + 1, sizeof(X) * (size - i));
         new (data + i) X(static_cast<X&&>(x));
@@ -198,7 +195,6 @@ class mal_vector {
      * Add an array of element to the end by copying existing values.
      */
     void append(size_t n, const X* xs) {
-        assert(n <= size);
         reserve(size + n);  // FIXME: Choose better size.
         for (size_t i = 0; i < n; i++) {
             new (data + size + i) X(xs[i]);
@@ -214,7 +210,6 @@ class mal_vector {
      * Remove the last element.
      */
     void pop() {
-        assert(size);
         data[size - 1].~X();
         size--;
     }
@@ -223,7 +218,6 @@ class mal_vector {
      * Remove an element.
      */
     void erase(size_t i) {
-        assert(i < size);
         for (size_t j = i; j < size - 1; j++) {
             data[j] = static_cast<X&&>(data[j + 1]);
         }
@@ -243,7 +237,6 @@ class mal_vector {
      * empty.
      */
     void reserve(size_t n) {
-        assert(n > capacity);
         X* newData = xmalloc(X, n);
         for (size_t i = 0; i < size; i++) {
             new (newData + i) X(static_cast<X&&>(data[i]));

--- a/Vector.h
+++ b/Vector.h
@@ -7,7 +7,6 @@
 #define xmalloc(T, count) \
     ((T*)malloc(sizeof(T) * (count)))
 
-// Does not call move constructors in its own move constructor or when growing.
 template<typename X>
 class mal_vector {
  public:

--- a/Vector.h
+++ b/Vector.h
@@ -206,7 +206,6 @@ class mal_vector {
         size += n;
     }
 
-
     //
     // Element removals
     //

--- a/Vector.h
+++ b/Vector.h
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define xmalloc(T, count) \
+    ((T*)malloc(sizeof(T) * (count)))
+
 // Does not call move constructors in its own move constructor or when growing.
 template<typename X>
 class mal_vector {
@@ -25,7 +28,7 @@ class mal_vector {
             size = capacity = 0;
         }
         else {
-            data = malloc(X, other.capacity);
+            data = xmalloc(X, other.capacity);
             size = other.size;
             capacity = other.capacity;
             for (size_t i = 0; i < size; i++) {
@@ -63,7 +66,7 @@ class mal_vector {
             size = capacity = 0;
         }
         else {
-            data = malloc(X, other.capacity);
+            data = xmalloc(X, other.capacity);
             size = other.size;
             capacity = other.capacity;
             for (size_t i = 0; i < size; i++) {
@@ -172,7 +175,7 @@ class mal_vector {
     // destructors on the just-moved objects since they are hopefully empty.
     void reserve(size_t n) {
         assert(n > capacity);
-        X* newData = malloc(X, n);
+        X* newData = xmalloc(X, n);
         for (size_t i = 0; i < size; i++) {
             new (newData + i) X(static_cast<X&&>(data[i]));
         }


### PR DESCRIPTION
This code may or may not compile. It is definitely not 100% ready to use, but this is my vector class from October 2020.

I've spent a decent amount of time optimizing it for small code size and it is designed to have small code size even when compiler optimizations are turned off. Most methods do not call other methods, which means that if only a few methods are invoked on a vector, most of the methods defined in the `.h` file will not go through code generation.

It makes a few assumptions about certain features in C++ not being used and exploits an intentional not handling of those to reduce code size. For example, it

- assumes that no exceptions are thrown during element constructors so it does not have code that handles those situations safely. This one should be okay since embedded code tends to not use exceptions anyway, and it
- sometimes assumes that its data elements can be moved without calling move/copy constructors, which means it cannot hold items that refer to themselves, for example.

Lifting the second assumption would require us to add about 6 lines of code and then test it.

It is intended that ~50% of the vector's use can be achieved through method calls and the other 50% by direct manipulation of `size` and `data` as if it's a C data structure. The `reset()` method endorses stealing the vector's memory when convenient, etc.

When using this class with plain-old-data types like `int` or `char*`, some of the `for`-loops become no-ops and are optimized out.